### PR TITLE
Fix Debian build compatibility and Makefile paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,13 @@ obj-m += hp-wmi.o
 # Kernel build directory
 KDIR := /lib/modules/$(shell uname -r)/build
 
-PKGNAME := $(shell grep -oP 'PACKAGE_NAME="\K[^"]+' dkms.conf)
-VERSION := $(shell grep -oP 'PACKAGE_VERSION="\K[^"]+' dkms.conf)
-
 # Current directory
 PWD := $(shell pwd)
+
+# Get package info from dkms.conf
+DKMS_CONF := $(PWD)/dkms.conf
+PKGNAME := $(shell grep -oP 'PACKAGE_NAME="\K[^"]+' $(DKMS_CONF) 2>/dev/null)
+VERSION := $(shell grep -oP 'PACKAGE_VERSION="\K[^"]+' $(DKMS_CONF) 2>/dev/null)
 
 # Default target
 all:

--- a/hp-wmi.c
+++ b/hp-wmi.c
@@ -529,7 +529,7 @@ static int hp_wmi_get_fan_count_userdefine_trigger(void)
 static void hp_victus_s_work_handler(struct work_struct *work)
 {
     hp_wmi_get_fan_count_userdefine_trigger();
-    schedule_delayed_work(to_delayed_work(work), secs_to_jiffies(HP_VICTUS_S_THERMAL_PROFILE_TIMER_SECONDS));
+    schedule_delayed_work(to_delayed_work(work), msecs_to_jiffies(HP_VICTUS_S_THERMAL_PROFILE_TIMER_SECONDS * 1000));
 }
 
 
@@ -2622,7 +2622,7 @@ static int hp_wmi_hwmon_write(struct device *dev, enum hwmon_sensor_types type,
 		}
 		break;
 	case hwmon_fan:
-		if (val > hp_fan_control.max_rpms[channel] && !force_fan_control_support || val < 0)
+		if ((val > hp_fan_control.max_rpms[channel] && !force_fan_control_support) || val < 0)
 			return -EINVAL;
 		if (hp_fan_control.have_manual_control) {
 			if (is_victus_s_thermal_profile())
@@ -2714,7 +2714,7 @@ static int __init hp_wmi_init(void)
 			goto err_unregister_device;
 
         INIT_DELAYED_WORK(&hp_fan_control.victus_s_thermal_profile_trigger_work, hp_victus_s_work_handler);
-        schedule_delayed_work(&hp_fan_control.victus_s_thermal_profile_trigger_work, secs_to_jiffies(HP_VICTUS_S_THERMAL_PROFILE_TIMER_SECONDS));
+        schedule_delayed_work(&hp_fan_control.victus_s_thermal_profile_trigger_work, msecs_to_jiffies(HP_VICTUS_S_THERMAL_PROFILE_TIMER_SECONDS * 1000));
 	}
 
 	return 0;


### PR DESCRIPTION
Description:
This PR fixes build issues specifically encountered on Debian systems.

Changes:
1. Makefile Path Fix: Updated dkms.conf lookup to use absolute paths.
2. Jiffies Compatibility: Replaced secs_to_jiffies with msecs_to_jiffies(s * 1000) to ensure compatibility across all kernel versions.
3. Logical Fix: Fixed a precedence warning in hp_wmi_hwmon_write by adding proper parentheses caused by new gcc version.

System Specifications:
- OS: Debian 13 Trixie
- Kernel: 6.12.73+deb13-amd64
- Compiler: gcc version 14.2.0 (Debian 14.2.0-19)

Error:

```bash
make -C /lib/modules/6.12.73+deb13-amd64/build M=/home/murat/workspace/hp-wmi-fan-and-backlight-control modules
make[1]: Entering directory '/usr/src/linux-headers-6.12.73+deb13-amd64'
grep: dkms.conf: No such file or directory
grep: dkms.conf: No such file or directory
  CC [M]  /home/murat/workspace/hp-wmi-fan-and-backlight-control/hp-wmi.o
/home/murat/workspace/hp-wmi-fan-and-backlight-control/hp-wmi.c: In function ‘hp_victus_s_work_handler’:
/home/murat/workspace/hp-wmi-fan-and-backlight-control/hp-wmi.c:532:50: error: implicit declaration of function ‘secs_to_jiffies’; did you mean ‘nsecs_to_jiffies’? [-Wimplicit-function-declaration]
  532 |     schedule_delayed_work(to_delayed_work(work), secs_to_jiffies(HP_VICTUS_S_THERMAL_PROFILE_TIMER_SECONDS));
      |                                                  ^~~~~~~~~~~~~~~
      |                                                  nsecs_to_jiffies
/home/murat/workspace/hp-wmi-fan-and-backlight-control/hp-wmi.c: In function ‘hp_wmi_hwmon_write’:
/home/murat/workspace/hp-wmi-fan-and-backlight-control/hp-wmi.c:2625:60: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
 2625 |                 if (val > hp_fan_control.max_rpms[channel] && !force_fan_control_support || val < 0)
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[3]: *** [/usr/src/linux-headers-6.12.73+deb13-common/scripts/Makefile.build:234: /home/murat/workspace/hp-wmi-fan-and-backlight-control/hp-wmi.o] Error 1
make[2]: *** [/usr/src/linux-headers-6.12.73+deb13-common/Makefile:1970: /home/murat/workspace/hp-wmi-fan-and-backlight-control] Error 2
make[1]: *** [/usr/src/linux-headers-6.12.73+deb13-common/Makefile:236: __sub-make] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-6.12.73+deb13-amd64'
make: *** [Makefile:16: all] Error 2
```